### PR TITLE
Game page restyle for chat

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -33,6 +33,13 @@ body {
   background-color: #1a2027;
 }
 
+.game-page-footer{
+  display: flex;
+  width: 80vw;
+  justify-content: space-evenly;
+  margin-top: 10px;
+}
+
 .score-container {
   width: 30%;
   min-width: 300px;

--- a/src/components/ClassicPage.jsx
+++ b/src/components/ClassicPage.jsx
@@ -47,8 +47,8 @@ export const ClassicPage = () => {
             </Button>
           )}
         </div>
-        {!runningGame && roundWord && (
-          <div>
+        {!runningGame && roundWord && !playerWonRound && (
+          <div className="padding-10">
             <span>{`The word was ${roundWord}`}</span>
           </div>
         )}

--- a/src/components/game-room/GamePage.jsx
+++ b/src/components/game-room/GamePage.jsx
@@ -102,23 +102,23 @@ export const GamePage = ({ user }) => {
                 </Box>
               </div>
             </Grid>
-            <Grid item xs={12}>
-              <div className="score-container margin-auto">
+            <div className="game-page-footer">
+              <Chat
+                roomId={roomId}
+                user={user}
+                messages={messages}
+                sendMessage={sendMessage}
+              />
+              <div className="score-container">
                 <Score
                   players={players}
                   username={username}
                   runningRound={runningRound}
                 />
               </div>
-            </Grid>
+            </div>
           </Grid>
         </div>
-        <Chat
-          roomId={roomId}
-          user={user}
-          messages={messages}
-          sendMessage={sendMessage}
-        />
       </div>
     </ThemeProvider>
   );

--- a/src/components/game-room/GamePage.jsx
+++ b/src/components/game-room/GamePage.jsx
@@ -76,7 +76,7 @@ export const GamePage = ({ user }) => {
                   )}
                 </>
               )}
-              {!runningGame && roundWord && (
+              {!runningGame && roundWord && !playerWonRound &&(
                 <div className="padding-10">
                   <span>{`The word was ${roundWord}`}</span>
                 </div>

--- a/src/components/word-game/WordBoard.jsx
+++ b/src/components/word-game/WordBoard.jsx
@@ -89,9 +89,7 @@ useEffect(() => {
         }
       </div>
       <div className="padding-10">
-        {(!solo || guesses.length < 6) && (
           <WordKeyboard guessedLetters={guessedLetters} />
-        )}
       </div>
 
     </div>


### PR DESCRIPTION
Make word display on round end not pop up if you won the round.
Removed code that breaks the classic page.
Fixes game page styling for chat component.